### PR TITLE
add default value for aliases variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,7 @@ variable "acm_certificate_arn" {
 }
 
 variable "aliases" {
+  default     = []
   description = "Extra CNAMEs (alternate domain names), if any, for this distribution."
   type        = "list"
 }


### PR DESCRIPTION
so that no need of passing this empty var from calling module if there is no need of cnames.